### PR TITLE
use specific types instead duplication

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -16,8 +16,8 @@ type UnmarshalFunc func([]byte, interface{}) error
 
 type Cache struct {
 	Redis     *redis.Pool
-	Marshal   func(interface{}) ([]byte, error)
-	Unmarshal func([]byte, interface{}) error
+	Marshal   MarshalFunc
+	Unmarshal UnmarshalFunc
 
 	conn   redis.Conn
 	hits   uint64


### PR DESCRIPTION
Sup, Michael!
I looked at your code and found out that you are not using the MarshalFunc and UnmarshalFunc types wherever you need it.

I would be glad if you accept my pull request!