### PR TITLE
not store first available connection, always get connection from pool

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -19,7 +19,6 @@ type Cache struct {
 	Marshal   func(interface{}) ([]byte, error)
 	Unmarshal func([]byte, interface{}) error
 
-	conn   redis.Conn
 	hits   uint64
 	misses uint64
 }
@@ -39,13 +38,12 @@ func NewRedisCache(redis *redis.Pool, marshalFunc MarshalFunc, unmarshalFunc Unm
 }
 
 func (c *Cache) getConn() (redis.Conn, error) {
-	if c.conn == nil {
-		conn := c.Redis.Get()
-		if err := conn.Err(); err != nil {
-			return conn, errors.WithStack(err)
-		}
+	conn := c.Redis.Get()
+	if err := conn.Err(); err != nil {
+		return conn, errors.WithStack(err)
 	}
-	return c.conn, nil
+
+	return conn, nil
 }
 
 func (c *Cache) Set(item *Item) error {


### PR DESCRIPTION
Wassup, man?
I found a strange code and I think it will interest you.
The fact is that the current code stop working if connection to Redis will be broken for some reason.
It happens because you get connection from pool once and reuse it throughout the program.
This pull request fixes this problem.